### PR TITLE
Support für andere DHBW Standorte

### DIFF
--- a/source/dhbw-titlepage-ba.def
+++ b/source/dhbw-titlepage-ba.def
@@ -30,7 +30,7 @@
     
     \bigskip
     des Studiengangs \getCourseName\par
-    der Dualen Hochschule Baden-Württemberg Mannheim
+    der Dualen Hochschule Baden-Württemberg \getDHBWLocation
     
     \vfill
     

--- a/source/dhbw-titlepage-pa.def
+++ b/source/dhbw-titlepage-pa.def
@@ -19,7 +19,7 @@
     
     \normalsize
     des Studiengangs \getCourseName\par
-    der Dualen Hochschule Baden-Württemberg Mannheim
+    der Dualen Hochschule Baden-Württemberg \getDHBWLocation
     
     \rule{\textwidth}{.5mm}\bigskip
     

--- a/source/dhbw-titlepage-sa.def
+++ b/source/dhbw-titlepage-sa.def
@@ -6,7 +6,7 @@
     
     \normalsize
     des Studiengangs \getCourseName\par
-    der Dualen Hochschule Baden-Württemberg Mannheim
+    der Dualen Hochschule Baden-Württemberg \getDHBWLocation
     
     \rule{\textwidth}{.5mm}\bigskip
 

--- a/source/dhbw-titlepage.def
+++ b/source/dhbw-titlepage.def
@@ -18,7 +18,7 @@
     
     \normalsize
     des Studiengangs Informationstechnik\par
-    der Dualen Hochschule Baden-Württemberg Mannheim
+    der Dualen Hochschule Baden-Württemberg \getDHBWLocation
     \end{center}
     
     \rule{\textwidth}{.5mm}\bigskip

--- a/source/iodhbwm-templates.sty
+++ b/source/iodhbwm-templates.sty
@@ -84,7 +84,7 @@
 \def\iodhbwm@bachelor@type@boa{Bachelor of Arts}
 
 \def\iodhbwm@dhbw@location@default{Mannheim}
-\def\iodhbwm@dhbw@logo@default{dhbw-logo.png}
+\def\iodhbwm@dhbw@logo@default{dhbw-logo}
 
 %---------------------------------------------------
 % Defining package options

--- a/source/iodhbwm-templates.sty
+++ b/source/iodhbwm-templates.sty
@@ -83,7 +83,8 @@
 \def\iodhbwm@bachelor@type@bos{Bachelor of Science}
 \def\iodhbwm@bachelor@type@boa{Bachelor of Arts}
 
-\def\iodhbwm@dhbwlocation@default{Mannheim}
+\def\iodhbwm@dhbw@location@default{Mannheim}
+\def\iodhbwm@dhbw@logo@default{dhbw-logo.png}
 
 %---------------------------------------------------
 % Defining package options
@@ -124,9 +125,12 @@
     submission date/.store in            = \iodhbwm@date@submission,
     location/.store in              = \iodhbwm@location,
     location                        = {},
-    dhbwlocation/.store in          = \iodhbwm@dhbwlocation,
-    dhbwlocation/.default           = \iodhbwm@dhbwlocation@default,
-    dhbwlocation                    = \iodhbwm@dhbwlocation@default,
+    dhbw location/.store in         = \iodhbwm@dhbw@location,
+    dhbw location/.default          = \iodhbwm@dhbw@location@default,
+    dhbw location                   = \iodhbwm@dhbw@location@default,
+    dhbw logo/.store in             = \iodhbwm@dhbw@logo,
+    dhbw logo/.default              = \iodhbwm@dhbw@logo@default,
+    dhbw logo                       = \iodhbwm@dhbw@logo@default,
     institute/.store in             = \iodhbwm@institute,
     institute section/.store in     = \iodhbwm@institute@section,
     institute section               = {},
@@ -303,14 +307,16 @@
     }{\iodhbwm@bachelor@degree}%
 }
 \newcommand{\getDHBWLocation}{%
-    \ifdefempty{\iodhbwm@dhbwlocation}{%
+    \ifdefempty{\iodhbwm@dhbw location}{%
         \PackageError{\iodhbwm@pkg@name}{%
-            Option dhbwlocation required!\MessageBreak
+            Option dhbw location required!\MessageBreak
             Please use\MessageBreak\protect\dhbwsetup{\MessageBreak
-                \space\space dhbwlocation = Location\MessageBreak
+                \space\space dhbw location = {Your DHBW Location}\MessageBreak
         }}{See documentation for more information}%
-    }{\iodhbwm@dhbwlocation}%
+    }{\iodhbwm@dhbw@location}%
 }
+\newcommand{\getDHBWLogo}{\iodhbwm@dhbw@logo}
+
 % ----------------------------------------------------------
 % Commands for structuring
 % ----------------------------------------------------------

--- a/source/iodhbwm-templates.sty
+++ b/source/iodhbwm-templates.sty
@@ -307,7 +307,7 @@
     }{\iodhbwm@bachelor@degree}%
 }
 \newcommand{\getDHBWLocation}{%
-    \ifdefempty{\iodhbwm@dhbw location}{%
+    \ifdefempty{\iodhbwm@dhbw@location}{%
         \PackageError{\iodhbwm@pkg@name}{%
             Option dhbw location required!\MessageBreak
             Please use\MessageBreak\protect\dhbwsetup{\MessageBreak

--- a/source/iodhbwm-templates.sty
+++ b/source/iodhbwm-templates.sty
@@ -77,11 +77,13 @@
 \edef\iodhbwm@file@titlepage@sa{\iodhbwm@file@prefix-titlepage-sa\iodhbwm@file@ending}
 \edef\iodhbwm@file@titlepage@pa{\iodhbwm@file@prefix-titlepage-pa\iodhbwm@file@ending}
 \edef\iodhbwm@file@declaration@default{\iodhbwm@file@prefix-declaration\iodhbwm@file@ending}
-\edef\iodhbw@file@abstract@default{\iodhbwm@file@prefix-abstract.inc}
+\edef\iodhbwm@file@abstract@default{\iodhbwm@file@prefix-abstract.inc}
 
 \def\iodhbwm@bachelor@type@boe{Bachelor of Engineering}
 \def\iodhbwm@bachelor@type@bos{Bachelor of Science}
 \def\iodhbwm@bachelor@type@boa{Bachelor of Arts}
+
+\def\iodhbwm@dhbwlocation@default{Mannheim}
 
 %---------------------------------------------------
 % Defining package options
@@ -95,8 +97,8 @@
     declaration/.default            = \iodhbwm@file@declaration@default,
     declaration                     = \iodhbwm@file@declaration@default,
     abstract/.store in              = \@iodhbwm@file@abstract,
-    abstract/.default               = \iodhbw@file@abstract@default,
-    abstract =                      = \iodhbw@file@abstract@default,
+    abstract/.default               = \iodhbwm@file@abstract@default,
+    abstract =                      = \iodhbwm@file@abstract@default,
     bachelor degree type/.store in  = \iodhbwm@bachelor@degree,
     bachelor degree type/.default   = \iodhbwm@bachelor@type@boe,
     bachelor degree type            = \iodhbwm@bachelor@type@boe,
@@ -122,6 +124,9 @@
     submission date/.store in            = \iodhbwm@date@submission,
     location/.store in              = \iodhbwm@location,
     location                        = {},
+    dhbwlocation/.store in          = \iodhbwm@dhbwlocation,
+    dhbwlocation/.default           = \iodhbwm@dhbwlocation@default,
+    dhbwlocation                    = \iodhbwm@dhbwlocation@default,
     institute/.store in             = \iodhbwm@institute,
     institute section/.store in     = \iodhbwm@institute@section,
     institute section               = {},
@@ -297,7 +302,15 @@
         }}{See documentation for more information}%
     }{\iodhbwm@bachelor@degree}%
 }
-
+\newcommand{\getDHBWLocation}{%
+    \ifdefempty{\iodhbwm@dhbwlocation}{%
+        \PackageError{\iodhbwm@pkg@name}{%
+            Option dhbwlocation required!\MessageBreak
+            Please use\MessageBreak\protect\dhbwsetup{\MessageBreak
+                \space\space dhbwlocation = Location\MessageBreak
+        }}{See documentation for more information}%
+    }{\iodhbwm@dhbwlocation}%
+}
 % ----------------------------------------------------------
 % Commands for structuring
 % ----------------------------------------------------------


### PR DESCRIPTION
Ich denke in ``source/iodhbwm-templates.sty@98`` sollte das ``iodhbwm`` heißen und nicht ``iodhbw``.

Unterstützung für alternative DHBW-Standorte hinzugefügt. ``dhbwstandort`` ist Standardmäßig Mannheim, außer wenn dieser Parameter gesetzt wird.