### PR TITLE
Fix #61 - Deleted deprecated option from \AfterPackage

### DIFF
--- a/source/iodhbwm.cls
+++ b/source/iodhbwm.cls
@@ -259,7 +259,7 @@
 % ----------------------------------------------------------
 % Enable references and links
 % ----------------------------------------------------------
-\AfterAtEndOfPackage*{hyperref}{%
+\AfterPackage*{hyperref}{%
     \ifdef{\iodhbwm@main@language}{%
         \PassOptionsToPackage{\iodhbwm@main@language}{cleveref}
     }{}


### PR DESCRIPTION
This PR fixes #61.

I had the same problem last week using TeX Live & Manjaro. After asking in StackExchange for a solution, one user pointed out the problem here: https://tex.stackexchange.com/questions/583459/tex-live-wont-work-with-custom-class-says-undefined-control-sequence-ifcref
